### PR TITLE
Add 'craft_guide' as optional dependency

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,3 @@
 default
 intllib?
+craft_guide?


### PR DESCRIPTION
Compatibility with [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/).