### PR TITLE
Intllib update

### DIFF
--- a/cgpsmap.lua
+++ b/cgpsmap.lua
@@ -9,7 +9,7 @@ local growing_wall_maps=false
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
   S = intllib.Getter(minetest.get_current_modname())
 else

--- a/cgpsmap.lua
+++ b/cgpsmap.lua
@@ -11,7 +11,11 @@ local growing_wall_maps=false
 local S
 if (minetest.global_exists("intllib")) then
   dofile(minetest.get_modpath("intllib").."/intllib.lua")
-  S = intllib.Getter(minetest.get_current_modname())
+  if (intllib.make_gettext_pair) then
+    S = intllib.make_gettext_pair(minetest.get_current_modname())
+  else
+    S = intllib.Getter(minetest.get_current_modname())
+  end
 else
   S = function ( s ) return s end
 end

--- a/init.lua
+++ b/init.lua
@@ -17,7 +17,11 @@
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
 if (minetest.global_exists("intllib")) then
-  S = intllib.Getter()
+  if (intllib.make_gettext_pair) then
+    S = intllib.make_gettext_pair()
+  else
+    S = intllib.Getter()
+  end
 else
   S = function ( s ) return s end
 end

--- a/init.lua
+++ b/init.lua
@@ -16,7 +16,7 @@
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
   S = intllib.Getter()
 else
   S = function ( s ) return s end


### PR DESCRIPTION
- Use *minetest.global_exists* in place of *minetest.get_modpath*
- Replace deprecated *intllib.Getter* with *intllib.make_gettext_pair*
  - Checks for *intllib.make_gettext_pair*, otherwise uses older *intllib.Getter*.